### PR TITLE
preserve control state of fields that are missing from the poll result

### DIFF
--- a/custom_components/chery_europe/coordinator.py
+++ b/custom_components/chery_europe/coordinator.py
@@ -162,7 +162,7 @@ class CheryEuropeDataUpdateCoordinator(DataUpdateCoordinator[CheryData]):
             merged = await self._merge_location(merged)
             self._sync_vehicle_identity(merged)
             self._apply_scan_interval(merged)
-            return self._preserve_status(merged)
+            return self._preserve_control_state(self._preserve_status(merged))
         except CheryEuropeAuthError as exc:
             raise ConfigEntryAuthFailed("Chery Europe authentication failed") from exc
         except Exception as exc:


### PR DESCRIPTION
Prevents specifically Scheduled Charging switch from getting stuck in 'ON' state because it's state is not returned in the poll json. 
This causes the switch to always turn off scheduled charging. 
With the fix the state from HA will be remembered, and thus scheduled charging can be turned on or off.