### PR TITLE
Prepare the integration for default HACS inclusion.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,22 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   hacs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hacs/action@main
+      - name: HACS validation
+        uses: hacs/action@main
         with:
           category: integration
-          # description/topics need GitHub repo settings; brands needs HA brands PR
-          ignore: brands description topics
 
   hassfest:
     name: Hassfest

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Joakim Sørensen @ludeeus
+Copyright (c) 2026 Przemysław Grzywa
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ or diagnostics.
 
 ### Requirements
 
-- Home Assistant **2026.5.4** or newer (see `hacs.json`)
+- Home Assistant **2026.5.0** or newer (see `hacs.json`)
 - Blueprints require Home Assistant **2024.10.0** or newer
 - A Chery Europe account (same email or phone as the official app)
 - Vehicle remote-control PIN (from the official app)
@@ -241,7 +241,7 @@ PIN **nie** trafia do logów ani diagnostyki.
 
 ### Wymagania
 
-- Home Assistant **2026.5.4** lub nowszy (patrz `hacs.json`)
+- Home Assistant **2026.5.0** lub nowszy (patrz `hacs.json`)
 - Blueprinty wymagają Home Assistant **2024.10.0** lub nowszego
 - Konto Chery Europe (ten sam e-mail lub telefon co w aplikacji)
 - PIN do zdalnego sterowania (z aplikacji)

--- a/hacs.json
+++ b/hacs.json
@@ -1,9 +1,4 @@
 {
   "name": "Chery Europe",
-  "content_in_root": false,
-  "country": [
-    "PL"
-  ],
-  "homeassistant": "2026.5.4",
-  "render_readme": true
+  "homeassistant": "2026.5.0"
 }


### PR DESCRIPTION
Drop the Poland-only country filter, require HA 2026.5.0, run HACS validation without ignored checks, and set the LICENSE copyright to the actual author.